### PR TITLE
Add Docker-in-Docker functionality with mount_docker_socket option

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -302,6 +302,11 @@ classpath = "my_package.my_module.MyCustomAgent"
 # Whether to initialize plugins
 #initialize_plugins = true
 
+# Mount Docker socket for Docker-in-Docker functionality
+# WARNING: This grants container access to the host Docker daemon with root-equivalent privileges
+# Use only in trusted environments
+#mount_docker_socket = false
+
 # Extra dependencies to install in the runtime image
 #runtime_extra_deps = ""
 

--- a/openhands/core/config/sandbox_config.py
+++ b/openhands/core/config/sandbox_config.py
@@ -87,6 +87,10 @@ class SandboxConfig(BaseModel):
         default=None,
         description="Volume mounts in the format 'host_path:container_path[:mode]', e.g. '/my/host/dir:/workspace:rw'. Multiple mounts can be specified using commas, e.g. '/path1:/workspace/path1,/path2:/workspace/path2:ro'",
     )
+    mount_docker_socket: bool = Field(
+        default=False,
+        description="Whether to mount the Docker socket to enable Docker-in-Docker functionality. WARNING: This grants container access to the host Docker daemon with root-equivalent privileges. Use only in trusted environments.",
+    )
 
     cuda_visible_devices: str | None = Field(default=None)
     model_config = ConfigDict(extra='forbid')

--- a/openhands/runtime/impl/docker/docker_runtime.py
+++ b/openhands/runtime/impl/docker/docker_runtime.py
@@ -355,6 +355,29 @@ class DockerRuntime(ActionExecutionClient):
                 'Mount dir is not set, will not mount the workspace directory to the container'
             )
             volumes = {}  # Empty dict instead of None to satisfy mypy
+        
+        # Conditionally mount Docker socket if configured
+        if self.config.sandbox.mount_docker_socket:
+            docker_socket_path = '/var/run/docker.sock'
+            # Check if Docker socket exists on host
+            if os.path.exists(docker_socket_path):
+                self.log(
+                    'warning',
+                    f'Mounting Docker socket to enable Docker-in-Docker functionality. '
+                    f'SECURITY WARNING: This grants container access to the host Docker daemon '
+                    f'with root-equivalent privileges. Use only in trusted environments.',
+                )
+                volumes[docker_socket_path] = {
+                    'bind': docker_socket_path,
+                    'mode': 'rw'
+                }
+            else:
+                self.log(
+                    'warning',
+                    f'Docker socket mounting requested but {docker_socket_path} not found on host. '
+                    f'Docker-in-Docker functionality will not be available.',
+                )
+        
         self.log(
             'debug',
             f'Sandbox workspace: {self.config.workspace_mount_path_in_sandbox}',

--- a/tests/unit/test_docker_runtime.py
+++ b/tests/unit/test_docker_runtime.py
@@ -165,3 +165,131 @@ def test_volumes_default_mode():
 
     # Assert that the mode remains 'rw' (default)
     assert volumes[os.path.abspath('/host/path')]['mode'] == 'rw'
+
+
+@patch('os.path.exists')
+@patch('openhands.runtime.impl.docker.docker_runtime.DockerRuntime._init_docker_client')
+def test_docker_socket_mounting_enabled_socket_exists(mock_init_docker, mock_exists, config, event_stream):
+    """Test that Docker socket is mounted when enabled and socket exists."""
+    # Arrange
+    mock_docker_client = MagicMock()
+    mock_docker_client.version.return_value = {
+        'Version': '20.10.0',
+        'Components': [{'Name': 'Engine', 'Version': '20.10.0'}],
+    }
+    mock_init_docker.return_value = mock_docker_client
+    mock_exists.return_value = True
+    config.sandbox.mount_docker_socket = True
+    runtime = DockerRuntime(config, event_stream, sid='test-sid')
+    runtime.log = MagicMock()
+    
+    # Mock the _process_volumes method to return empty dict
+    runtime._process_volumes = MagicMock(return_value={})
+    
+    # Mock other required methods and attributes
+    runtime._find_available_port = MagicMock(side_effect=[30000, 40000, 50000, 55000])
+    runtime.get_action_execution_server_startup_command = MagicMock(return_value='test-command')
+    runtime.set_runtime_status = MagicMock()
+    runtime.initial_env_vars = {}
+    runtime._vscode_enabled = False  # Mock the private attribute
+    runtime.runtime_container_image = 'test-image'
+    
+    # Act
+    runtime.init_container()
+    
+    # Assert
+    mock_exists.assert_called_with('/var/run/docker.sock')
+    runtime.log.assert_any_call(
+        'warning',
+        'Mounting Docker socket to enable Docker-in-Docker functionality. '
+        'SECURITY WARNING: This grants container access to the host Docker daemon '
+        'with root-equivalent privileges. Use only in trusted environments.'
+    )
+    
+    # Check that docker.containers.run was called with the Docker socket mounted
+    call_args = mock_docker_client.containers.run.call_args
+    volumes_arg = call_args[1]['volumes']
+    assert '/var/run/docker.sock' in volumes_arg
+    assert volumes_arg['/var/run/docker.sock']['bind'] == '/var/run/docker.sock'
+    assert volumes_arg['/var/run/docker.sock']['mode'] == 'rw'
+
+
+@patch('os.path.exists')
+@patch('openhands.runtime.impl.docker.docker_runtime.DockerRuntime._init_docker_client')
+def test_docker_socket_mounting_enabled_socket_not_exists(mock_init_docker, mock_exists, config, event_stream):
+    """Test that warning is logged when Docker socket mounting is enabled but socket doesn't exist."""
+    # Arrange
+    mock_docker_client = MagicMock()
+    mock_docker_client.version.return_value = {
+        'Version': '20.10.0',
+        'Components': [{'Name': 'Engine', 'Version': '20.10.0'}],
+    }
+    mock_init_docker.return_value = mock_docker_client
+    mock_exists.return_value = False
+    config.sandbox.mount_docker_socket = True
+    runtime = DockerRuntime(config, event_stream, sid='test-sid')
+    runtime.log = MagicMock()
+    
+    # Mock the _process_volumes method to return empty dict
+    runtime._process_volumes = MagicMock(return_value={})
+    
+    # Mock other required methods and attributes
+    runtime._find_available_port = MagicMock(side_effect=[30000, 40000, 50000, 55000])
+    runtime.get_action_execution_server_startup_command = MagicMock(return_value='test-command')
+    runtime.set_runtime_status = MagicMock()
+    runtime.initial_env_vars = {}
+    runtime._vscode_enabled = False  # Mock the private attribute
+    runtime.runtime_container_image = 'test-image'
+    
+    # Act
+    runtime.init_container()
+    
+    # Assert
+    mock_exists.assert_called_with('/var/run/docker.sock')
+    runtime.log.assert_any_call(
+        'warning',
+        'Docker socket mounting requested but /var/run/docker.sock not found on host. '
+        'Docker-in-Docker functionality will not be available.'
+    )
+    
+    # Check that docker.containers.run was called without the Docker socket mounted
+    call_args = mock_docker_client.containers.run.call_args
+    assert call_args is not None, "docker.containers.run should have been called"
+    volumes_arg = call_args[1]['volumes']
+    assert '/var/run/docker.sock' not in volumes_arg
+
+
+@patch('openhands.runtime.impl.docker.docker_runtime.DockerRuntime._init_docker_client')
+def test_docker_socket_mounting_disabled(mock_init_docker, config, event_stream):
+    """Test that Docker socket is not mounted when disabled."""
+    # Arrange
+    mock_docker_client = MagicMock()
+    mock_docker_client.version.return_value = {
+        'Version': '20.10.0',
+        'Components': [{'Name': 'Engine', 'Version': '20.10.0'}],
+    }
+    mock_init_docker.return_value = mock_docker_client
+    config.sandbox.mount_docker_socket = False
+    runtime = DockerRuntime(config, event_stream, sid='test-sid')
+    runtime.log = MagicMock()
+    
+    # Mock the _process_volumes method to return empty dict
+    runtime._process_volumes = MagicMock(return_value={})
+    
+    # Mock other required methods and attributes
+    runtime._find_available_port = MagicMock(side_effect=[30000, 40000, 50000, 55000])
+    runtime.get_action_execution_server_startup_command = MagicMock(return_value='test-command')
+    runtime.set_runtime_status = MagicMock()
+    runtime.initial_env_vars = {}
+    runtime._vscode_enabled = False  # Mock the private attribute
+    runtime.runtime_container_image = 'test-image'
+    
+    # Act
+    runtime.init_container()
+    
+    # Assert
+    # Check that docker.containers.run was called without the Docker socket mounted
+    call_args = mock_docker_client.containers.run.call_args
+    assert call_args is not None, "docker.containers.run should have been called"
+    volumes_arg = call_args[1]['volumes']
+    assert '/var/run/docker.sock' not in volumes_arg


### PR DESCRIPTION
## Summary

This PR adds Docker-in-Docker functionality to OpenHands by implementing a new `mount_docker_socket` configuration option that allows mounting the host Docker socket into the sandbox container.

## Changes Made

### Configuration
- **Added `mount_docker_socket` option** to `SandboxConfig` with default value `False`
- **Added security warning** in the field description about root-equivalent privileges
- **Updated `config.template.toml`** with documentation and security warnings

### Runtime Implementation
- **Modified `DockerRuntime.init_container()`** to conditionally mount Docker socket
- **Added host path existence check** before mounting (`/var/run/docker.sock`)
- **Added comprehensive logging** with security warnings and error messages
- **Integrated with existing volume processing** to avoid conflicts

### Testing
- **Added 3 comprehensive test cases**:
  - Docker socket mounting when enabled and socket exists
  - Warning logging when enabled but socket doesn't exist  
  - No mounting when disabled
- **All tests pass** with proper mocking and assertions

## Security Considerations

⚠️ **IMPORTANT SECURITY WARNING**: This feature grants the container access to the host Docker daemon with root-equivalent privileges. It should only be used in trusted environments.

The implementation includes:
- Multiple security warnings in configuration and logs
- Default disabled state (`mount_docker_socket = false`)
- Clear documentation about security implications
- Host path existence validation

## Usage

To enable Docker-in-Docker functionality:

```toml
[sandbox]
mount_docker_socket = true
```

Or via environment variable:
```bash
SANDBOX__MOUNT_DOCKER_SOCKET=true
```

## Testing

All existing tests continue to pass, and new tests specifically cover:
- ✅ Docker socket mounting when enabled and socket exists
- ✅ Warning messages when socket doesn't exist
- ✅ No mounting when feature is disabled

## Backward Compatibility

This change is fully backward compatible:
- Default behavior unchanged (`mount_docker_socket = false`)
- No impact on existing configurations
- All existing functionality preserved

## Related

This addresses the need for Docker-in-Docker functionality that was requested in previous discussions, enabling use cases like:
- Building Docker images within the sandbox
- Running containerized applications
- Testing Docker-based workflows

The implementation follows security best practices with clear warnings and safe defaults.